### PR TITLE
Fix errors thrown when deploying

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -28,3 +28,6 @@ jobs:
 
       - name: Run tests
         run: deno test
+    
+      - name: Run type check
+        run: deno check *.ts && deno check **/*.ts && deno check **/**/*.ts

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2022- Slack Technologies, LLC
+Copyright (c) 2023- Slack Technologies, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/functions/format_rotation/handler.ts
+++ b/functions/format_rotation/handler.ts
@@ -2,9 +2,7 @@ import { SlackFunction } from "deno-slack-sdk/mod.ts";
 import { FormatRotationFunctionDefinition } from "./definition.ts";
 
 export default SlackFunction(FormatRotationFunctionDefinition, ({ inputs }) => {
-  const next_users = inputs.rotation.order.slice(1).map((a: string) =>
-    `<@${a}>`
-  ).join(
+  const next_users = inputs.rotation.order.slice(1).map((a) => `<@${a}>`).join(
     ", ",
   );
 

--- a/functions/format_rotation/handler.ts
+++ b/functions/format_rotation/handler.ts
@@ -2,7 +2,9 @@ import { SlackFunction } from "deno-slack-sdk/mod.ts";
 import { FormatRotationFunctionDefinition } from "./definition.ts";
 
 export default SlackFunction(FormatRotationFunctionDefinition, ({ inputs }) => {
-  const next_users = inputs.rotation.order.slice(1).map((a) => `<@${a}>`).join(
+  const next_users = inputs.rotation.order.slice(1).map((a: string) =>
+    `<@${a}>`
+  ).join(
     ", ",
   );
 

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.5.1/",
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.4/",
     "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.6.0/"
   }
 }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

There was a report in issue https://github.com/slack-samples/deno-triage-rotation/issues/4 that when attempting to deploy, errors are now being thrown.

I am unsure what the root cause of this could be (Deno update? some sort of dependency update?), as I was able to deploy this app successfully a few weeks ago, but the root of the current error being thrown was that the `a` variable in the `.map()` statement of `functions/format_rotation/handler.ts` was not explicitly typed, so the original solution in this PR was updated it to point to a `string` type, as it appears to reference user IDs.

After discussion with @filmaj about the root of this issue, this PR has been reworked to:
* Add a CI check to make sure this type of error gets caught in the CI, and
* Roll back the app's Deno SDK version to 1.4.4

**Testing**
1. Create a new app using this branch: `slack create -t slack-samples/deno-triage-rotation -b fix-issue-4`
2. In the new project, run `slack deploy`

App should successfully deploy with no errors

### Requirements (place an x in each [ ] that applies)

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
