### PR TITLE
Update records with `datastore.update` when advancing rotations

### DIFF
--- a/functions/advance_rotation/handler.ts
+++ b/functions/advance_rotation/handler.ts
@@ -22,7 +22,9 @@ export default SlackFunction(
     const assignees = [...assigneeOrder, first];
 
     // 2: update the rotation in the datastore
-    const putResponse = await client.apps.datastore.update({
+    const putResponse = await client.apps.datastore.update<
+      typeof RotationDatastore.definition
+    >({
       datastore: RotationDatastore.name,
       item: {
         channel,

--- a/import_map.json
+++ b/import_map.json
@@ -1,6 +1,6 @@
 {
   "imports": {
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.4.4/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.6.0/"
+    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@1.6.0/",
+    "deno-slack-api/": "https://deno.land/x/deno_slack_api@1.7.0/"
   }
 }

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.9.2/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@0.9.3/mod.ts"
   }
 }


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

To showcase [a new datastore operation](https://api.slack.com/future/changelog#v1-20-0), this PR replaces the `datastore.put` call in the `advance_rotation` function with `datastore.update`. With this call, only the fields passed into this function will be updated with the primary key `channel`, while those unspecified are not modified.

The versions of Deno modules were also bumped to support this new function.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)