### PR TITLE
Update inline reference links to match the API docs URLs

### DIFF
--- a/datastores/rotations.ts
+++ b/datastores/rotations.ts
@@ -4,7 +4,7 @@ import { DatastoreItem } from "deno-slack-api/types.ts";
 /**
  * Datastores are a Slack-hosted location to store
  * and retrieve data for your app.
- * https://api.slack.com/future/datastores
+ * https://api.slack.com/automation/datastores
  */
 const RotationDatastore = DefineDatastore({
   name: "rotations",

--- a/functions/advance_rotation/definition.ts
+++ b/functions/advance_rotation/definition.ts
@@ -9,7 +9,7 @@ export const ADVANCE_ROTATION_FUNCTION_CALLBACK_ID = "advance_rotation_fn";
  * rotation and updates the RotationsDatabase with a new order
 
  * More on defining functions here:
- * https://api.slack.com/future/functions/custom
+ * https://api.slack.com/automation/functions/custom
  */
 export const AdvanceRotationFunctionDefinition = DefineFunction({
   callback_id: ADVANCE_ROTATION_FUNCTION_CALLBACK_ID,

--- a/functions/create_rotation/definition.ts
+++ b/functions/create_rotation/definition.ts
@@ -8,7 +8,7 @@ const CREATE_ROTATION_FUNCTION_CALLBACK_ID = "create_rotation";
  * some inputs describing the form, validates, and saves to a database
  *
  * More on defining functions here:
- * https://api.slack.com/future/functions/custom
+ * https://api.slack.com/automation/functions/custom
  */
 export const CreateRotationFunctionDefinition = DefineFunction({
   callback_id: CREATE_ROTATION_FUNCTION_CALLBACK_ID,

--- a/functions/create_rotation/handler.ts
+++ b/functions/create_rotation/handler.ts
@@ -165,7 +165,7 @@ export function getNextAdvanceTimeInSec(
  * This helper function returns a `schedule` object for a scheduled workflow
  * trigger. For more information on `schedule` object properties:
  *
- * https://api.slack.com/future/triggers/scheduled#schedule
+ * https://api.slack.com/automation/triggers/scheduled#schedule
  */
 // deno-lint-ignore no-explicit-any
 export function getTriggerSchedule(debugMode: boolean, inputs: any) {
@@ -182,7 +182,7 @@ export function getTriggerSchedule(debugMode: boolean, inputs: any) {
    * To set this value for production apps, use the `slack env var add`.
    *
    * More on using environment variables:
-   * https://api.slack.com/future/run#environment-variables
+   * https://api.slack.com/automation/environment-variables
    */
   if (debugMode) {
     console.log("DEBUG MODE IS ON");
@@ -208,7 +208,7 @@ export function getTriggerSchedule(debugMode: boolean, inputs: any) {
  * This helper function returns a frequency object required to create a
  * a scheduled workflow trigger. For more information on the scheduled
  * trigger `frequency` object properties:
- * https://api.slack.com/future/triggers/scheduled#frequency
+ * https://api.slack.com/automation/triggers/scheduled#frequency
  */
 // deno-lint-ignore no-explicit-any
 function getTriggerScheduleFrequency(inputs: any) {

--- a/functions/format_rotation/definition.ts
+++ b/functions/format_rotation/definition.ts
@@ -13,7 +13,7 @@ const FORMAT_ROTATION_FUNCTION_CALLBACK_ID = "format_rotation";
  * with existing values supplied.
  *
  * More on defining functions here:
- * https://api.slack.com/future/functions/custom
+ * https://api.slack.com/automation/functions/custom
  */
 export const FormatRotationFunctionDefinition = DefineFunction({
   callback_id: FORMAT_ROTATION_FUNCTION_CALLBACK_ID,

--- a/functions/get_rotation/definition.ts
+++ b/functions/get_rotation/definition.ts
@@ -9,7 +9,7 @@ export const GET_ROTATION_FUNCTION_CALLBACK_ID = "get_rotation";
  * datastore definition: /datastores/rotations.ts
  *
  * More on defining functions here:
- * https://api.slack.com/future/functions/custom
+ * https://api.slack.com/automation/functions/custom
  */
 export const GetRotationFunctionDefinition = DefineFunction({
   callback_id: GET_ROTATION_FUNCTION_CALLBACK_ID,

--- a/functions/get_rotation/handler.ts
+++ b/functions/get_rotation/handler.ts
@@ -14,7 +14,7 @@ export default SlackFunction(
   async ({ inputs, client }) => {
     // Step 1: check rotation datastore for existing records associated with channel id
     // For more info on how to format datastore queries:
-    // https://api.slack.com/future/datastores#query_multiple
+    // https://api.slack.com/automation/datastores#query_multiple
     const queryResp = await client.apps.datastore.query<
       typeof RotationDatastore.definition
     >({

--- a/functions/open_form/definition.ts
+++ b/functions/open_form/definition.ts
@@ -13,7 +13,7 @@ export const OPEN_FORM_FUNCTION_CALLBACK_ID = "open_form";
  * the form will be opened with existing values supplied.
  *
  * More on defining functions here:
- * https://api.slack.com/future/functions/custom
+ * https://api.slack.com/automation/functions/custom
  */
 export const OpenFormFunctionDefinition = DefineFunction({
   callback_id: OPEN_FORM_FUNCTION_CALLBACK_ID,

--- a/functions/open_form/interaction_handler.ts
+++ b/functions/open_form/interaction_handler.ts
@@ -122,7 +122,7 @@ export const endFunctionWithError: ViewClosedHandler<
    * function with an error and a helpful message for logging.
    *
    * For more on logging activity:
-   * https://api.slack.com/future/logging
+   * https://api.slack.com/automation/logging
    */
   return client.functions.completeError({
     function_execution_id,

--- a/triggers/manage_rotation.ts
+++ b/triggers/manage_rotation.ts
@@ -9,7 +9,7 @@ import ManageRotationWorkflow from "../workflows/manage_rotation.ts";
  * such as a user pressing a button or when a specific event occurs.
  *
  * For more on triggers:
- * https://api.slack.com/future/triggers
+ * https://api.slack.com/automation/triggers
  */
 const manageRotationWorkflow: Trigger<
   typeof ManageRotationWorkflow.definition

--- a/types/user_array.ts
+++ b/types/user_array.ts
@@ -5,7 +5,7 @@ import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
  * ids. This array is used as the rotation order for our app.
  *
  * For more on defining custom types:
- * https://api.slack.com/future/types/custom
+ * https://api.slack.com/automation/types/custom
  */
 export default DefineType({
   name: "user_array",

--- a/workflows/advance_rotation.ts
+++ b/workflows/advance_rotation.ts
@@ -6,10 +6,10 @@ import { FormatRotationFunctionDefinition } from "../functions/format_rotation/d
 /**
  * A workflow is a set of steps that are executed in order.
  * Each step in a workflow is a function.
- * https://api.slack.com/future/workflows
+ * https://api.slack.com/automation/workflows
  *
  * This workflow uses interactivity. Learn more at:
- * https://api.slack.com/future/forms#add-interactivity
+ * https://api.slack.com/automation/forms#add-interactivity
  */
 const AdvanceRotationWorkflow = DefineWorkflow({
   callback_id: "advance_rotation",

--- a/workflows/manage_rotation.ts
+++ b/workflows/manage_rotation.ts
@@ -6,10 +6,10 @@ import { OpenFormFunctionDefinition } from "../functions/open_form/definition.ts
 /**
  * A workflow is a set of steps that are executed in order.
  * Each step in a workflow is a function.
- * https://api.slack.com/future/workflows
+ * https://api.slack.com/automation/workflows
  *
  * This workflow uses interactivity. Learn more at:
- * https://api.slack.com/future/forms#add-interactivity
+ * https://api.slack.com/automation/forms#add-interactivity
  */
 const ManageRotationWorkflow = DefineWorkflow({
   callback_id: "manage_rotation",
@@ -21,7 +21,7 @@ const ManageRotationWorkflow = DefineWorkflow({
    * and more.
    *
    * For more on adding input parameters:
-   * https://api.slack.com/future/workflows#workflow-adding-input-parameters
+   * https://api.slack.com/automation/workflows#defining-input-parameters
    *
    * Where do the values for this workflow's input parameters come from? Check out
    * the trigger for this workflow /triggers/manage_rotation.ts
@@ -66,7 +66,7 @@ const currentRotationStep = ManageRotationWorkflow.addStep(
  * For more info on Block Kit interactivity: https://api.slack.com/block-kit/interactivity
  *
  * Don't need interactivity? Checkout the the built-in OpenForm function.
- * https://api.slack.com/future/functions#open-a-form
+ * https://api.slack.com/reference/functions/open_form
  */
 const formStep = ManageRotationWorkflow.addStep(
   OpenFormFunctionDefinition,


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [ ] New feature
- [ ] Bug fix
- [x] Documentation

### Summary

This PR updates inline reference links to use the corresponding `/automation` links on [api.slack.com](https://api.slack.com)!

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
