### PR TITLE
Remove package CDNs from `outgoingDomains` for the deployed app

### DIFF
--- a/manifest.ts
+++ b/manifest.ts
@@ -7,7 +7,7 @@ import UserArray from "./types/user_array.ts";
 /**
  * The app manifest contains the app's configuration. This
  * file defines attributes like app name and description.
- * https://api.slack.com/future/manifest
+ * https://api.slack.com/automation/manifest
  */
 export default Manifest({
   name: "Rotation App",
@@ -15,7 +15,9 @@ export default Manifest({
     "Create and manage an ordered work rotation and list of assignees",
   icon: "assets/icon.png",
   workflows: [ManageRotationWorkflow, AdvanceRotationWorkflow],
-  outgoingDomains: ["cdn.skypack.dev"],
+  outgoingDomains: Deno.env.get("SLACK_ENV") === "deployed"
+    ? []
+    : ["cdn.skypack.dev"],
   types: [UserArray],
   datastores: [RotationDatastore],
   botScopes: [


### PR DESCRIPTION
### Type of change

- [ ] New sample
- [x] New feature
- [ ] Bug fix
- [ ] Documentation

### Summary

This PR includes `cdn.skypack.dev` in the `outgoingDomains` for only the local app since this package is automatically bundled when packaging the deployed app.

The change is made to help expedite app approval processes by removing outgoing domains from the deployed app to make this app fully hosted.

### Reviewers

These changes can be verified with both a local and deployed app by running these apps with a scheduled rotation to ensure the rotation happens.

The change to outgoing domains in the manifest can be checked by viewing the manifest for the corresponding app IDs here: https://api.slack.com/methods/apps.manifest.export/test

### Notes

- This might cause additional confusion but is a workaround for `npm:` specifiers for packages without using a CDN for now. No hard feelings if this approach isn't favored!
- Comparing `Deno.env.get("SLACK_ENV") === "deployed"` instead of `Deno.env.get("SLACK_ENV") === "local"` here to fallback to including the outgoing domain if the environment isn't specified.

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
