### PR TITLE
Support npm specifiers

### DIFF
--- a/functions/open_form/blocks.ts
+++ b/functions/open_form/blocks.ts
@@ -8,7 +8,7 @@ import {
   MultiUsersSelect,
   Option,
   SectionBlock,
-} from "https://cdn.skypack.dev/@slack/types?dts";
+} from "npm:@slack/types";
 
 import { Rotation } from "../../datastores/rotations.ts";
 import { WEEKDAY } from "../create_rotation/handler.ts";

--- a/functions/open_form/blocks.ts
+++ b/functions/open_form/blocks.ts
@@ -8,7 +8,7 @@ import {
   MultiUsersSelect,
   Option,
   SectionBlock,
-} from "npm:@slack/types";
+} from "npm:@slack/types@2.11";
 
 import { Rotation } from "../../datastores/rotations.ts";
 import { WEEKDAY } from "../create_rotation/handler.ts";

--- a/slack.json
+++ b/slack.json
@@ -1,5 +1,5 @@
 {
   "hooks": {
-    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.1.0/mod.ts"
+    "get-hooks": "deno run -q --allow-read --allow-net https://deno.land/x/deno_slack_hooks@1.2.0/mod.ts"
   }
 }


### PR DESCRIPTION
### Type of change (place an x in the [ ] that applies)

- [ ] New sample
- [ ] New feature
- [x] Bug fix
- [ ] Documentation

### Summary

This PR aims to update the version of the `deno-slack-hooks` package and enable the project to use `npm` specifiers to import packages

This also resolves #32 

### Testing

1. Pull this branch
2. Run `slack deploy`
3. The project should bundle and deploy as expected

### Requirements

- [x] I’ve checked my submission against the Samples Checklist to ensure it complies with all standards
- [x] I have ensured the changes I am contributing align with existing patterns and have tested and linted my code
- [x] I've read and agree to the [Code of Conduct](https://slackhq.github.io/code-of-conduct)
