### PR TITLE
chore: update Deno imports to use JSR

### DIFF
--- a/datastores/rotations.ts
+++ b/datastores/rotations.ts
@@ -1,5 +1,5 @@
-import { DefineDatastore, Schema } from "deno-slack-sdk/mod.ts";
-import { DatastoreItem } from "deno-slack-api/types.ts";
+import { DefineDatastore, Schema } from "@slack/sdk";
+import { DatastoreItem } from "@slack/api/types";
 
 /**
  * Datastores are a Slack-hosted location to store

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -31,7 +31,7 @@
   },
   "imports": {
     "@slack/api": "jsr:@slack/api@2.9.0",
-    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2",
     "@slack/sdk/functions/interactivity/types": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/main/src/functions/interactivity/types.ts",
     "@slack/api-scheduled-trigger": "https://raw.githubusercontent.com/slackapi/deno-slack-api/main/src/typed-method-types/workflows/triggers/scheduled.ts",
     "@slack/types": "npm:@slack/types@^2.18.0",

--- a/deno.jsonc
+++ b/deno.jsonc
@@ -30,9 +30,11 @@
     "test": "deno fmt --check && deno lint && deno test --allow-read"
   },
   "imports": {
+    "@slack/api": "jsr:@slack/api@2.9.0",
+    "@slack/sdk": "jsr:@slack/sdk@2.15.2-dev.1",
+    "@slack/sdk/functions/interactivity/types": "https://raw.githubusercontent.com/slackapi/deno-slack-sdk/main/src/functions/interactivity/types.ts",
+    "@slack/api-scheduled-trigger": "https://raw.githubusercontent.com/slackapi/deno-slack-api/main/src/typed-method-types/workflows/triggers/scheduled.ts",
     "@slack/types": "npm:@slack/types@^2.18.0",
-    "deno-slack-sdk/": "https://deno.land/x/deno_slack_sdk@2.15.1/",
-    "deno-slack-api/": "https://deno.land/x/deno_slack_api@2.8.0/",
     "@std/assert": "jsr:@std/assert@^1.0.15",
     "@std/testing": "jsr:@std/testing@^1.0.16"
   }

--- a/functions/advance_rotation/definition.ts
+++ b/functions/advance_rotation/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 
 import RotationDatastore from "../../datastores/rotations.ts";
 

--- a/functions/advance_rotation/handler.ts
+++ b/functions/advance_rotation/handler.ts
@@ -1,5 +1,5 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
-import { DatastoreItem } from "deno-slack-api/types.ts";
+import { SlackFunction } from "@slack/sdk";
+import { DatastoreItem } from "@slack/api/types";
 
 import { AdvanceRotationFunctionDefinition } from "./definition.ts";
 

--- a/functions/advance_rotation/handler_test.ts
+++ b/functions/advance_rotation/handler_test.ts
@@ -1,4 +1,4 @@
-import { SlackFunctionTester } from "deno-slack-sdk/mod.ts";
+import { SlackFunctionTester } from "@slack/sdk";
 import { assertEquals } from "@std/assert";
 import AdvanceRotationFunction from "./handler.ts";
 import { ADVANCE_ROTATION_FUNCTION_CALLBACK_ID } from "./definition.ts";

--- a/functions/create_rotation/definition.ts
+++ b/functions/create_rotation/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction } from "deno-slack-sdk/mod.ts";
+import { DefineFunction } from "@slack/sdk";
 import { OpenFormFunctionDefinition } from "../open_form/definition.ts";
 
 const CREATE_ROTATION_FUNCTION_CALLBACK_ID = "create_rotation";

--- a/functions/create_rotation/handler.ts
+++ b/functions/create_rotation/handler.ts
@@ -1,6 +1,6 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
-import { DatastoreItem } from "deno-slack-api/types.ts";
-import { ScheduledTrigger } from "deno-slack-api/typed-method-types/workflows/triggers/scheduled.ts";
+import { SlackFunction } from "@slack/sdk";
+import { DatastoreItem } from "@slack/api/types";
+import { ScheduledTrigger } from "@slack/api-scheduled-trigger";
 
 import { CreateRotationFunctionDefinition } from "./definition.ts";
 

--- a/functions/format_rotation/definition.ts
+++ b/functions/format_rotation/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, DefineProperty, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, DefineProperty, Schema } from "@slack/sdk";
 import UserArray from "../../types/user_array.ts";
 
 const FORMAT_ROTATION_FUNCTION_CALLBACK_ID = "format_rotation";

--- a/functions/format_rotation/handler.ts
+++ b/functions/format_rotation/handler.ts
@@ -1,4 +1,4 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 import { FormatRotationFunctionDefinition } from "./definition.ts";
 
 export default SlackFunction(FormatRotationFunctionDefinition, ({ inputs }) => {

--- a/functions/get_rotation/definition.ts
+++ b/functions/get_rotation/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 import RotationDatastore from "../../datastores/rotations.ts";
 
 export const GET_ROTATION_FUNCTION_CALLBACK_ID = "get_rotation";

--- a/functions/get_rotation/handler.ts
+++ b/functions/get_rotation/handler.ts
@@ -1,4 +1,4 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 
 import { GetRotationFunctionDefinition } from "./definition.ts";
 

--- a/functions/open_form/definition.ts
+++ b/functions/open_form/definition.ts
@@ -1,4 +1,4 @@
-import { DefineFunction, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineFunction, Schema } from "@slack/sdk";
 import RotationDatastore from "../../datastores/rotations.ts";
 
 import UserArray from "../../types/user_array.ts";

--- a/functions/open_form/handler.ts
+++ b/functions/open_form/handler.ts
@@ -1,4 +1,4 @@
-import { SlackFunction } from "deno-slack-sdk/mod.ts";
+import { SlackFunction } from "@slack/sdk";
 
 import { OpenFormFunctionDefinition } from "./definition.ts";
 import {

--- a/functions/open_form/interaction_handler.ts
+++ b/functions/open_form/interaction_handler.ts
@@ -2,7 +2,7 @@ import {
   BlockActionHandler,
   ViewClosedHandler,
   ViewSubmissionHandler,
-} from "deno-slack-sdk/functions/interactivity/types.ts";
+} from "@slack/sdk/functions/interactivity/types";
 
 import RotationDatastore from "../../datastores/rotations.ts";
 import { OpenFormFunctionDefinition as OpenFormFunction } from "./definition.ts";

--- a/manifest.ts
+++ b/manifest.ts
@@ -1,4 +1,4 @@
-import { Manifest } from "deno-slack-sdk/mod.ts";
+import { Manifest } from "@slack/sdk";
 import AdvanceRotationWorkflow from "./workflows/advance_rotation.ts";
 import ManageRotationWorkflow from "./workflows/manage_rotation.ts";
 import RotationDatastore from "./datastores/rotations.ts";

--- a/triggers/manage_rotation.ts
+++ b/triggers/manage_rotation.ts
@@ -1,4 +1,4 @@
-import { Trigger } from "deno-slack-sdk/types.ts";
+import { Trigger } from "@slack/sdk/types.ts";
 import ManageRotationWorkflow from "../workflows/manage_rotation.ts";
 /**
  * This is the definition for a shortcut trigger that will

--- a/types/user_array.ts
+++ b/types/user_array.ts
@@ -1,4 +1,4 @@
-import { DefineType, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineType, Schema } from "@slack/sdk";
 
 /**
  * This custom type is used to define a array of slack user

--- a/workflows/advance_rotation.ts
+++ b/workflows/advance_rotation.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { GetRotationFunctionDefinition } from "../functions/get_rotation/definition.ts";
 import { AdvanceRotationFunctionDefinition } from "../functions/advance_rotation/definition.ts";
 import { FormatRotationFunctionDefinition } from "../functions/format_rotation/definition.ts";

--- a/workflows/manage_rotation.ts
+++ b/workflows/manage_rotation.ts
@@ -1,4 +1,4 @@
-import { DefineWorkflow, Schema } from "deno-slack-sdk/mod.ts";
+import { DefineWorkflow, Schema } from "@slack/sdk";
 import { CreateRotationFunctionDefinition } from "../functions/create_rotation/definition.ts";
 import { GetRotationFunctionDefinition } from "../functions/get_rotation/definition.ts";
 import { OpenFormFunctionDefinition } from "../functions/open_form/definition.ts";


### PR DESCRIPTION
Updates deno-slack-sdk and deno-slack-api imports to use the new JSR packages (@slack/sdk and @slack/api).

Made with [Cursor](https://cursor.com)